### PR TITLE
Add run-replayer --start-slot-since-genesis

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,7 @@ pub enum NodeCommand {
     /// Get precomputed blocks from a node
     DumpPrecomputedBlocks(NodeCommandArgs),
     /// Get logs by replaying an archive node's database
-    RunReplayer(NodeCommandArgs),
+    RunReplayer(ReplayerCommandArgs),
 }
 
 #[derive(Args, Debug)]
@@ -84,6 +84,12 @@ pub struct NodeId {
 pub struct FreshState {
     #[clap(short = 'f', long)]
     pub fresh_state: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct Slot {
+    #[clap(short = 's', long)]
+    pub start_slot_since_genesis: u32,
 }
 
 #[derive(Args, Debug)]
@@ -107,6 +113,18 @@ pub struct NodeCommandStartArgs {
     pub node_id: NodeId,
 }
 
+#[derive(Args, Debug)]
+pub struct ReplayerCommandArgs {
+    #[clap(flatten)]
+    pub network_id: NetworkId,
+
+    #[clap(flatten)]
+    pub node_id: NodeId,
+
+    #[clap(flatten)]
+    pub start_slot_since_genesis: Slot,
+}
+
 impl NodeCommandArgs {
     pub fn node_id(&self) -> &str {
         &self.node_id.node_id
@@ -118,6 +136,16 @@ impl NodeCommandArgs {
 }
 
 impl NodeCommandStartArgs {
+    pub fn node_id(&self) -> &str {
+        &self.node_id.node_id
+    }
+
+    pub fn network_id(&self) -> &str {
+        &self.network_id.network_id
+    }
+}
+
+impl ReplayerCommandArgs {
     pub fn node_id(&self) -> &str {
         &self.node_id.node_id
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ fn main() {
                     logs: "log0\nlog1\nlog2".to_string(),
                     network_id: cmd.network_id().to_string(),
                     node_id: cmd.node_id().to_string(),
+                    start_slot_since_genesis: 0,
                 });
             }
         },

--- a/src/output.rs
+++ b/src/output.rs
@@ -86,6 +86,7 @@ pub mod node {
         pub logs: String,
         pub network_id: String,
         pub node_id: String,
+        pub start_slot_since_genesis: u32,
     }
 }
 


### PR DESCRIPTION
This PR introduces a new cli arg `--start-slot-since-genesis` for `mock-network node run-replayer`

Closes https://github.com/MinaFoundation/mock-network/issues/5